### PR TITLE
HUB-3573: Add synchronous tx mail handler (no queueing)

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -144,6 +144,7 @@ func initHTTPHandlers(e *echo.Echo, app *App) {
 	g.DELETE("/api/maintenance/subscriptions/unconfirmed", handleGCSubscriptions)
 
 	g.POST("/api/tx", handleSendTxMessage)
+	g.POST("/api/custom/txsync", handleSendTxMessageSync)
 
 	if app.constants.BounceWebhooksEnabled {
 		// Private authenticated bounce endpoint.

--- a/cmd/txSync.go
+++ b/cmd/txSync.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/textproto"
+
+	"github.com/knadh/listmonk/internal/messenger"
+	"github.com/knadh/listmonk/models"
+	"github.com/labstack/echo/v4"
+)
+
+// handleSendTxMessageSync handles the sending of a transactional message.
+func handleSendTxMessageSync(c echo.Context) error {
+	var (
+		app = c.Get("app").(*App)
+		m   models.TxMessage
+	)
+
+	if err := c.Bind(&m); err != nil {
+		return err
+	}
+
+	// Validate input.
+	if r, err := validateTxMessageSync(m, app); err != nil {
+		return err
+	} else {
+		m = r
+	}
+
+	// Get the cached tx template.
+	tpl, err := app.manager.GetTpl(m.TemplateID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			app.i18n.Ts("globals.messages.notFound", "name", fmt.Sprintf("template %d", m.TemplateID)))
+	}
+
+	// Get the subscriber.
+	sub, err := app.core.GetSubscriber(m.SubscriberID, "", m.SubscriberEmail)
+	if err != nil {
+		var httpErr *echo.HTTPError
+		// If subscriber email is defined but unknown (StatusBadRequest), we can continue
+		if (errors.As(err, &httpErr) && httpErr.Code != http.StatusBadRequest) || m.SubscriberEmail == "" {
+			return err
+		}
+		sub.Email = m.SubscriberEmail
+	}
+
+	// Render the message.
+	if err := m.Render(sub, tpl); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			app.i18n.Ts("globals.messages.errorFetching", "name"))
+	}
+
+	// Prepare the final message.
+	msg := messenger.Message{}
+	msg.Subscriber = sub
+	msg.To = []string{sub.Email}
+	msg.From = m.FromEmail
+	msg.Subject = m.Subject
+	msg.ContentType = m.ContentType
+	msg.Body = m.Body
+
+	// Optional headers.
+	if len(m.Headers) != 0 {
+		msg.Headers = make(textproto.MIMEHeader, len(m.Headers))
+		for _, set := range m.Headers {
+			for hdr, val := range set {
+				msg.Headers.Add(hdr, val)
+			}
+		}
+	}
+
+	err = app.messengers[m.Messenger].Push(msg)
+	if err != nil {
+		app.log.Printf("error sending message '%s': %v", msg.Subject, err)
+		if (err.Error() == "timed out waiting for free conn in pool") {
+			return echo.NewHTTPError(http.StatusTooManyRequests, err.Error())
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, okResp{true})
+}
+
+func validateTxMessageSync(m models.TxMessage, app *App) (models.TxMessage, error) {
+	if m.SubscriberEmail == "" && m.SubscriberID == 0 {
+		return m, echo.NewHTTPError(http.StatusBadRequest,
+			app.i18n.Ts("globals.messages.missingFields", "name", "subscriber_email or subscriber_id"))
+	}
+
+	if m.SubscriberEmail != "" {
+		em, err := app.importer.SanitizeEmail(m.SubscriberEmail)
+		if err != nil {
+			return m, echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		m.SubscriberEmail = em
+	}
+
+	if m.FromEmail == "" {
+		m.FromEmail = app.constants.FromEmail
+	}
+
+	if m.Messenger == "" {
+		m.Messenger = emailMsgr
+	} else if !app.manager.HasMessenger(m.Messenger) {
+		return m, echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("campaigns.fieldInvalidMessenger", "name", m.Messenger))
+	}
+
+	return m, nil
+}


### PR DESCRIPTION
### Added

- custom endpoint `/api/custom/txsync` which sends emails synchronously, i.e., circumventing queues and workers