### PR TITLE
HUB-3642: configurable allowed FROM addresses per SMTP server

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -90,8 +90,6 @@ func handleUpdateSettings(c echo.Context) error {
 				}
 			}
 		}
-
-		// todo: check that there is at least one smtp without allowed from-address constraints
 	}
 	if !has {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("settings.errorNoSMTP"))

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -90,6 +90,8 @@ func handleUpdateSettings(c echo.Context) error {
 				}
 			}
 		}
+
+		// todo: check that there is at least one smtp without allowed from-address constraints
 	}
 	if !has {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.T("settings.errorNoSMTP"))
@@ -230,10 +232,11 @@ func handleTestSMTPSettings(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, app.i18n.Ts("globals.messages.missingFields", "name", "email"))
 	}
 
-	// Initialize a new SMTP pool.
+	// Initialize a new SMTP pool. Ignore allow list for from-addresses.
 	req.MaxConns = 1
 	req.IdleTimeout = time.Second * 2
 	req.PoolWaitTimeout = time.Second * 2
+	req.AllowedFromAddresses = []string{}
 	msgr, err := email.New(req)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest,

--- a/frontend/src/views/settings/smtp.vue
+++ b/frontend/src/views/settings/smtp.vue
@@ -144,6 +144,17 @@
               </div>
             </div>
 
+            <b-field :label="$t('settings.smtp.allowedFromAddresses')" label-position="on-border"
+              :message="$t('settings.smtp.allowedFromAddressesHelp')">
+              <b-taginput
+                v-model="item.allowed_from_addresses"
+                name="allowed_from_addresses"
+                :before-adding="(v) => v.match(/^([^\s@]+?@)?([^\s@]+?)$/)"
+                placeholder='you@yoursite.com'
+              />
+            </b-field>
+            <hr />
+
             <div class="columns">
               <div class="column">
                 <p v-if="item.email_headers.length === 0 && !item.showHeaders">

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -468,6 +468,8 @@
     "settings.smtp.testConnection": "Test connection",
     "settings.smtp.testEnterEmail": "Enter password to test",
     "settings.smtp.toEmail": "To e-mail",
+    "settings.smtp.allowedFromAddresses": "Allowed FROM addresses/domains for this server (leave empty to allow all)",
+    "settings.smtp.allowedFromAddressesHelp": "Comma separated list of allowed FROM e-mail addresses/domains this SMTP server may be used for. Leave empty to allow all FROM addresses/domains for this SMTP server.",
     "settings.title": "Settings",
     "settings.updateAvailable": "A new update {version} is available.",
     "subscribers.advancedQuery": "Advanced",

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -95,8 +95,8 @@ func (e *Emailer) Name() string {
 func emailAddressMatchesAllowlist(emailAddress string, allowedFromAddresses []string) bool {
 	domain := strings.Split(emailAddress, "@")[1]
 
-	for _, allowedAddress := range allowedFromAddresses {
-		if emailAddress == allowedAddress || domain == allowedAddress {
+	for _, allowed := range allowedFromAddresses {
+		if emailAddress == allowed || domain == allowed {
 			return true
 		}
 	}

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -16,6 +16,12 @@ import (
 
 const emName = "email"
 
+// define error messages
+var (
+	ErrEmailNoSMTPServerForFrom = errors.New("no applicable SMTP server for FROM address")
+	ErrEmailInvalidFromAddress  = errors.New("invalid FROM email address")
+)
+
 // Server represents an SMTP server's credentials.
 type Server struct {
 	Username             string            `json:"username"`
@@ -106,7 +112,7 @@ func emailAddressMatchesAllowlist(emailAddress string, allowedFromAddresses []st
 func applicableServers(servers []*Server, fromAddress string) (applServers []*Server, err error) {
 	parsedFromAddress, err := mail.ParseAddress(fromAddress)
 	if err != nil {
-		return applServers, errors.New("invalid FROM email address")
+		return applServers, ErrEmailInvalidFromAddress
 	}
 
 	for _, smtpServer := range servers {
@@ -134,7 +140,7 @@ func (e *Emailer) Push(m messenger.Message) error {
 	if ln > 0 {
 		srv = applicableServers[rand.Intn(ln)]
 	} else {
-		return errors.New("no applicable SMTP server for FROM address")
+		return ErrEmailNoSMTPServerForFrom
 	}
 
 	// Are there attachments?

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -131,12 +131,10 @@ func (e *Emailer) Push(m messenger.Message) error {
 		srv *Server
 	)
 
-	if ln == 0 {
-		return errors.New("no applicable SMTP server for FROM address")
-	} else if ln > 1 {
+	if ln > 0 {
 		srv = applicableServers[rand.Intn(ln)]
 	} else {
-		srv = applicableServers[0]
+		return errors.New("no applicable SMTP server for FROM address")
 	}
 
 	// Are there attachments?

--- a/internal/messenger/email/email.go
+++ b/internal/messenger/email/email.go
@@ -134,9 +134,9 @@ func (e *Emailer) Push(m messenger.Message) error {
 	if ln == 0 {
 		return errors.New("no applicable SMTP server for FROM address")
 	} else if ln > 1 {
-		srv = e.servers[rand.Intn(ln)]
+		srv = applicableServers[rand.Intn(ln)]
 	} else {
-		srv = e.servers[0]
+		srv = applicableServers[0]
 	}
 
 	// Are there attachments?

--- a/models/settings.go
+++ b/models/settings.go
@@ -44,21 +44,22 @@ type Settings struct {
 	UploadS3Expiry             string `json:"upload.s3.expiry"`
 
 	SMTP []struct {
-		UUID          string              `json:"uuid"`
-		Enabled       bool                `json:"enabled"`
-		Host          string              `json:"host"`
-		HelloHostname string              `json:"hello_hostname"`
-		Port          int                 `json:"port"`
-		AuthProtocol  string              `json:"auth_protocol"`
-		Username      string              `json:"username"`
-		Password      string              `json:"password,omitempty"`
-		EmailHeaders  []map[string]string `json:"email_headers"`
-		MaxConns      int                 `json:"max_conns"`
-		MaxMsgRetries int                 `json:"max_msg_retries"`
-		IdleTimeout   string              `json:"idle_timeout"`
-		WaitTimeout   string              `json:"wait_timeout"`
-		TLSType       string              `json:"tls_type"`
-		TLSSkipVerify bool                `json:"tls_skip_verify"`
+		UUID                 string              `json:"uuid"`
+		Enabled              bool                `json:"enabled"`
+		Host                 string              `json:"host"`
+		HelloHostname        string              `json:"hello_hostname"`
+		Port                 int                 `json:"port"`
+		AuthProtocol         string              `json:"auth_protocol"`
+		Username             string              `json:"username"`
+		Password             string              `json:"password,omitempty"`
+		EmailHeaders         []map[string]string `json:"email_headers"`
+		AllowedFromAddresses []string            `json:"allowed_from_addresses"`
+		MaxConns             int                 `json:"max_conns"`
+		MaxMsgRetries        int                 `json:"max_msg_retries"`
+		IdleTimeout          string              `json:"idle_timeout"`
+		WaitTimeout          string              `json:"wait_timeout"`
+		TLSType              string              `json:"tls_type"`
+		TLSSkipVerify        bool                `json:"tls_skip_verify"`
 	} `json:"smtp"`
 
 	Messengers []struct {


### PR DESCRIPTION
- adds configuration option `allowed FROM addresses/domains` to STMP server configuration screen in listmonks admin UI (see screenshot)
- changes SMTP server selection logic in backend: configured servers are filtered by matching the message's `FROM` field against the servers allowed FROM addresses/domains
- txSync API returns 400 in case no SMTP server is matching or if the FROM address cannot be parsed

<img width="998" alt="image" src="https://user-images.githubusercontent.com/88392294/216411381-f26d369c-a9e1-4f7a-b21b-219cc31c50bf.png">
